### PR TITLE
Remove update Rake task description

### DIFF
--- a/lib/i18n-js/rake.rb
+++ b/lib/i18n-js/rake.rb
@@ -9,8 +9,7 @@ namespace "i18n:js" do
     SimplesIdeias::I18n.export!
   end
 
-  desc "Update the JavaScript library"
-  task :update => :environment do
+  task :upgrade_i18njs => :environment do
     SimplesIdeias::I18n.update!
   end
 end


### PR DESCRIPTION
This was causing confusion and also broke our codebases in IE when the
update task was run.

Renamed it to upgrade_i18njs instead.

cc @chrisbarber86 @asmega

Fixes https://github.com/Sage/sop/issues/1621
