### PR TITLE
UI-1834

### DIFF
--- a/spec/i18n_spec.js
+++ b/spec/i18n_spec.js
@@ -820,7 +820,7 @@ describe("I18n.js", function(){
 });
 
 // Setup test to ensure a preset I18n.locale passes correctly
-var I18n = {}
+var I18n = {};
 I18n.locale = "en_IE";
 
 load("vendor/assets/javascripts/i18n.js");
@@ -828,5 +828,16 @@ load("vendor/assets/javascripts/i18n.js");
 describe("I18n.js when I18n.locale has already been set", function(){
   specify("with custom locale", function(){
     expect(I18n.locale).toBeEqualTo("en_IE");
+  });
+});
+
+// Setup test to ensure no i18n.locale has been passed
+var I18n = {};
+
+load("vendor/assets/javascripts/i18n.js");
+
+describe("I18n.js when no i18n.locale is passed", function(){
+  specify("locale to be null", function(){
+    expect(I18n.locale).toBeEqualTo(null);
   });
 });

--- a/spec/i18n_spec.js
+++ b/spec/i18n_spec.js
@@ -818,3 +818,15 @@ describe("I18n.js", function(){
     expect(I18n.findAndTranslateValidNode(["one"], {})).toBeEqualTo(null);
   });
 });
+
+// Setup test to ensure a preset I18n.locale passes correctly
+var I18n = {}
+I18n.locale = "en_IE";
+
+load("vendor/assets/javascripts/i18n.js");
+
+describe("I18n.js when I18n.locale has already been set", function(){
+  specify("with custom locale", function(){
+    expect(I18n.locale).toBeEqualTo("en_IE");
+  });
+});

--- a/vendor/assets/javascripts/i18n.js
+++ b/vendor/assets/javascripts/i18n.js
@@ -10,8 +10,8 @@ I18n.fallbacks = false;
 // Set default separator
 I18n.defaultSeparator = ".";
 
-// Set current locale to null
-I18n.locale = null;
+// Set current locale to null if not already set
+I18n.locale = I18n.locale || null;
 
 // Set the placeholder format. Accepts `{{placeholder}}` and `%{placeholder}`.
 I18n.PLACEHOLDER = /(?:\{\{|%\{)(.*?)(?:\}\}?)/gm;


### PR DESCRIPTION
Relates to: https://sageone.atlassian.net/browse/UI-1834

Changed i18n.js to accept passes i18n.locale value if provided before initialize.
